### PR TITLE
Suffix for ais-saved-movements.log should be by date 

### DIFF
--- a/wildfly-base/src/main/docker/cli-scripts/uvms_configuration.cli
+++ b/wildfly-base/src/main/docker/cli-scripts/uvms_configuration.cli
@@ -53,7 +53,7 @@ embed-server --server-config=${SERVER_CONFIG}
 /subsystem=logging/logging-profile=ais/pattern-formatter=ONLYMSG-PATTERN:add(pattern="%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %m%n")
 /subsystem=logging/logging-profile=ais/size-rotating-file-handler=ais-file:add(level=INFO,file={path=>"/app/logs/ais/ais.log"},named-formatter=APP-PATTERN,suffix=".yyyy-MM-dd_HHmmss.zip",rotate-size=50M, max-backup-index=40)
 /subsystem=logging/logging-profile=ais/size-rotating-file-handler=ais-error-file:add(level=ERROR,file={path=>"/app/logs/ais/ais-error.log"},named-formatter=APP-PATTERN,suffix=".yyyy-MM-dd_HHmmss.zip",rotate-size=50M, max-backup-index=40)
-/subsystem=logging/logging-profile=ais/size-rotating-file-handler=ais-saved-movements-file:add(level=INFO,file={path=>"/app/logs/ais/ais-saved-movements.log"},named-formatter=ONLYMSG-PATTERN,suffix=".zip",rotate-size=50M, max-backup-index=100)
+/subsystem=logging/logging-profile=ais/size-rotating-file-handler=ais-saved-movements-file:add(level=INFO,file={path=>"/app/logs/ais/ais-saved-movements.log"},named-formatter=ONLYMSG-PATTERN,suffix=".yyyy-MM-dd.zip",rotate-size=50M, max-backup-index=100)
 /subsystem=logging/logging-profile=ais/logger=fish.focus:add(handlers=[ais-file,ais-error-file])
 /subsystem=logging/logging-profile=ais/logger=SAVED_MOVEMENTS:add(handlers=[ais-saved-movements-file])
 


### PR DESCRIPTION
Should not rotate by number by default (where the same during 20231005 -20231016 in prod) .
Have manually set in prod 2023-12-08 13:10 
```bash
[standalone@localhost:9990 /] /subsystem=logging/logging-profile=ais/size-rotating-file-handler=ais-saved-movements-file:write-attribute(name=suffix, value=".yyyy-MM-dd.zip")
{"outcome" => "success"}
```