### PR TITLE
fix: bump geoserver to 2.25.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<unionvms.wildfly.version>26.0.0.Final</unionvms.wildfly.version>
 		<unionvms.project.unionvms.web.version>3.0.80</unionvms.project.unionvms.web.version>
 		<unionvms.project.vms.web.version>1.1.37</unionvms.project.vms.web.version>
-		<unionvms.project.geoserver.version>2.19.6.0</unionvms.project.geoserver.version>
+		<unionvms.project.geoserver.version>2.25.3.0</unionvms.project.geoserver.version>
 		<unionvms.project.user.module>2.2.6</unionvms.project.user.module>
 		<unionvms.project.reporting.module>1.1.31</unionvms.project.reporting.module>
 		<unionvms.project.movementrules.module>2.4.21</unionvms.project.movementrules.module>

--- a/unionvms-test/src/test/java/fish/focus/uvms/docker/validation/geoserver/GeoserverIT.java
+++ b/unionvms-test/src/test/java/fish/focus/uvms/docker/validation/geoserver/GeoserverIT.java
@@ -1,8 +1,8 @@
 package fish.focus.uvms.docker.validation.geoserver;
 
-import org.junit.Test;
 import fish.focus.uvms.docker.validation.common.AbstractRest;
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -10,85 +10,105 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import static javax.ws.rs.core.Response.Status.*;
+import static org.junit.Assert.assertEquals;
+
 public class GeoserverIT extends AbstractRest {
 
-	@Test
-	public void verifyProtectedUvmsLayersTest() {
-		Response response = geoServerWebTarget()
-				.path("uvms/wms")
-				.queryParam("service", "WMS")
-				.queryParam("version", "1.1.0")
-				.queryParam("request", "GetMap")
-				.queryParam("layers", "uvms:port")
-				.queryParam("styles", "")
-				.queryParam("bbox", "-180.0,-90.0,180.0,90.0")
-				.queryParam("width", "768")
-				.queryParam("height", "384")
-				.queryParam("srs", "EPSG:4326")
-				.queryParam("format", "application/openlayers")
-				.request(MediaType.APPLICATION_JSON)
-				.get();
+    @Test
+    public void verifyProtectedUvmsLayersTest() {
+        Response response = geoServerWebTarget()
+                .path("uvms/wms")
+                .queryParam("service", "WMS")
+                .queryParam("version", "1.1.0")
+                .queryParam("request", "GetMap")
+                .queryParam("layers", "uvms:port")
+                .queryParam("styles", "")
+                .queryParam("bbox", "-180.0,-90.0,180.0,90.0")
+                .queryParam("width", "768")
+                .queryParam("height", "384")
+                .queryParam("srs", "EPSG:4326")
+                .queryParam("format", "application/openlayers")
+                .request(MediaType.APPLICATION_JSON)
+                .get();
 
-		assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
-	}
+        assertEquals(FORBIDDEN.getStatusCode(), response.getStatus());
+    }
 
-	@Test
-	public void verifyProtectedUvmsLayersAccessWithJwtHeaderTest() {
-		Response response = geoServerWebTarget()
-				.path("uvms/wms")
-				.queryParam("service", "WMS")
-				.queryParam("version", "1.1.0")
-				.queryParam("request", "GetMap")
-				.queryParam("layers", "uvms:port")
-				.queryParam("styles", "")
-				.queryParam("bbox", "-180.0,-90.0,180.0,90.0")
-				.queryParam("width", "768")
-				.queryParam("height", "384")
-				.queryParam("srs", "EPSG:4326")
-				.queryParam("format", "application/openlayers")
-				.request(MediaType.APPLICATION_JSON)
-				.header(HttpHeaders.AUTHORIZATION, getValidJwtToken())
-				.get();
+    @Test
+    public void verifyProtectedUvmsLayersAccessWithJwtHeaderTest() {
+        Response response = geoServerWebTarget()
+                .path("uvms/wms")
+                .queryParam("service", "WMS")
+                .queryParam("version", "1.1.0")
+                .queryParam("request", "GetMap")
+                .queryParam("layers", "uvms:port")
+                .queryParam("styles", "")
+                .queryParam("bbox", "-180.0,-90.0,180.0,90.0")
+                .queryParam("width", "768")
+                .queryParam("height", "384")
+                .queryParam("srs", "EPSG:4326")
+                .queryParam("format", "application/openlayers")
+                .request(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, getValidJwtToken())
+                .get();
 
-		assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-		assertEquals("SAMEORIGIN", response.getHeaderString("X-Frame-Options"));
-	}	
-	
-	@Test
-	public void verifyAccessControlAllowOriginTest() {
-		Response response = geoServerWebTarget()
-				.path("web/")
-				.request(MediaType.APPLICATION_JSON)
-				.header(HttpHeaders.AUTHORIZATION, getValidJwtToken())
-				.header("Origin", "http://www.example.com")
-				.get();
+        assertEquals(OK.getStatusCode(), response.getStatus());
+        assertEquals("SAMEORIGIN", response.getHeaderString("X-Frame-Options"));
+    }
 
-		assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-		assertEquals("SAMEORIGIN", response.getHeaderString("X-Frame-Options"));
-		assertEquals("http://www.example.com", response.getHeaderString("Access-Control-Allow-Origin"));
-		assertEquals("true", response.getHeaderString("Access-Control-Allow-Credentials"));
-	}
+    @Test
+    public void verifyAccessControlAllowOriginTest() {
+        Response response = geoServerWebTarget()
+                .path("web/")
+                .request(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, getValidJwtToken())
+                .header("Origin", "http://www.example.com")
+                .get();
 
-	@Test
-	public void verifyOptionsAllowTest() {
-		Response response = geoServerWebTarget()
-				.path("web")
-				.request(MediaType.APPLICATION_JSON)
-				.header(HttpHeaders.AUTHORIZATION, getValidJwtToken())
-				.header("Origin", "http://www.example.com")
-				.header("Access-Control-Request-Method", "POST")
-				.header("Access-Control-Request-Headers", "X-Requested-With,Content-Type,Accept,Authorization")
-				.options();
+        if (response.getStatus() == FOUND.getStatusCode()) {
+            // From 2.25 local and CI differs in responses.
+            // (or possibly earlier since > 2.19.6 were never tested until 2.25 was introduced)
+            // Locally, the first request returns 302 while on CI it returns 200.
+            var request = ClientBuilder.newClient()
+                    .target(response.getLocation())
+                    .request(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, getValidJwtToken())
+                    .header("Origin", "http://www.example.com");
 
-		assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-		assertEquals("http://www.example.com", response.getHeaderString("Access-Control-Allow-Origin"));
-		assertEquals("true", response.getHeaderString("Access-Control-Allow-Credentials"));
-		assertEquals("GET,POST,PUT,DELETE,HEAD,OPTIONS", response.getHeaderString("Access-Control-Allow-Methods"));
-		assertEquals("X-Requested-With,Content-Type,Accept,Authorization", response.getHeaderString("Access-Control-Allow-Headers"));
-	}
+            for (var cookie : response.getCookies().values()) {
+                request.cookie(cookie);
+            }
 
-	private WebTarget geoServerWebTarget() {
-		Client client = ClientBuilder.newClient();
-		return client.target("http://localhost:28080/geoserver/");
-	}
+            response = request.get();
+        }
+
+        assertEquals(OK.getStatusCode(), response.getStatus());
+        assertEquals("SAMEORIGIN", response.getHeaderString("X-Frame-Options"));
+        assertEquals("http://www.example.com", response.getHeaderString("Access-Control-Allow-Origin"));
+        assertEquals("true", response.getHeaderString("Access-Control-Allow-Credentials"));
+    }
+
+    @Test
+    public void verifyOptionsAllowTest() {
+        Response response = geoServerWebTarget()
+                .path("web")
+                .request(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, getValidJwtToken())
+                .header("Origin", "http://www.example.com")
+                .header("Access-Control-Request-Method", "POST")
+                .header("Access-Control-Request-Headers", "X-Requested-With,Content-Type,Accept,Authorization")
+                .options();
+
+        assertEquals(OK.getStatusCode(), response.getStatus());
+        assertEquals("http://www.example.com", response.getHeaderString("Access-Control-Allow-Origin"));
+        assertEquals("true", response.getHeaderString("Access-Control-Allow-Credentials"));
+        assertEquals("GET,POST,PUT,DELETE,HEAD,OPTIONS", response.getHeaderString("Access-Control-Allow-Methods"));
+        assertEquals("X-Requested-With,Content-Type,Accept,Authorization", response.getHeaderString("Access-Control-Allow-Headers"));
+    }
+
+    private WebTarget geoServerWebTarget() {
+        Client client = ClientBuilder.newClient();
+        return client.target("http://localhost:28080/geoserver/");
+    }
 }


### PR DESCRIPTION
/geoserver/web in newer versions seems to redirect (302) instead of responding with 200 on GET requests.
GeoserverIT.verifyAccessControlAllowOriginTest has been updated accordingly.