### PR TITLE
fix: bump geoserver version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <unionvms.wildfly.version>26.0.0.Final</unionvms.wildfly.version>
         <unionvms.project.unionvms.web.version>3.0.80</unionvms.project.unionvms.web.version>
         <unionvms.project.vms.web.version>1.1.37</unionvms.project.vms.web.version>
-        <unionvms.project.geoserver.version>2.25.3.0</unionvms.project.geoserver.version>
+        <unionvms.project.geoserver.version>2.25.3.1</unionvms.project.geoserver.version>
         <unionvms.project.user.module>2.2.6</unionvms.project.user.module>
         <unionvms.project.reporting.module>1.1.31</unionvms.project.reporting.module>
         <unionvms.project.movementrules.module>2.4.21</unionvms.project.movementrules.module>


### PR DESCRIPTION
Includes the exclusion of commons-lang3.