### PR TITLE
test: flakey Metrics integration test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <unionvms.project.incident.module>1.0.15</unionvms.project.incident.module>
         <unionvms.project.activity.module>1.2.18</unionvms.project.activity.module>
         <unionvms.project.web-gateway>1.0.9</unionvms.project.web-gateway>
-        <unionvms.project.plugins.ais>3.1.32</unionvms.project.plugins.ais>
+        <unionvms.project.plugins.ais>3.1.33</unionvms.project.plugins.ais>
         <unionvms.project.plugins.naf>3.1.12</unionvms.project.plugins.naf>
         <unionvms.project.plugins.flux>3.1.13</unionvms.project.plugins.flux>
         <unionvms.project.plugins.inmarsat>3.1.15</unionvms.project.plugins.inmarsat>

--- a/unionvms-test/pom.xml
+++ b/unionvms-test/pom.xml
@@ -18,6 +18,7 @@
         <docker.skip>${skipITs}</docker.skip>
         <docker.frontend.test.suite>UnionVMSTestCaseG2</docker.frontend.test.suite>
         <uvms.commons.version>4.1.15</uvms.commons.version>
+        <uvms.pom.version>3.23</uvms.pom.version>
     </properties>
 
     <dependencies>
@@ -145,16 +146,6 @@
             <artifactId>flux-movement-plugin-model</artifactId>
             <version>${unionvms.project.plugins.flux}</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>2.0.13</version>
-        </dependency>
         <dependency> <!-- Mute jboss-logging -->
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
@@ -193,8 +184,15 @@
         <dependency>
             <groupId>fish.focus.uvms.maven</groupId>
             <artifactId>uvms-pom-java11-deps</artifactId>
-            <version>3.22</version>
+            <version>${uvms.pom.version}</version>
             <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>fish.focus.uvms.maven</groupId>
+            <artifactId>uvms-pom-test-deps</artifactId>
+            <version>${uvms.pom.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/unionvms-test/src/test/java/fish/focus/uvms/docker/validation/system/MetricsIT.java
+++ b/unionvms-test/src/test/java/fish/focus/uvms/docker/validation/system/MetricsIT.java
@@ -18,14 +18,11 @@ import org.junit.Test;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MetricsIT extends AbstractRest {
 
@@ -39,37 +36,31 @@ public class MetricsIT extends AbstractRest {
     public void inmarsatIncoming() throws Exception {
         try (MessageHelper messageHelper = new MessageHelper()) {
             messageHelper.sendMessage("UVMSInmarsatMessages", "test");
-            TimeUnit.SECONDS.sleep(1);
         }
-        assertThat(getMetricValue(INMARSAT_INCOMING), is(notNullValue()));
+        await().until(() -> getMetricValue(INMARSAT_INCOMING), is(notNullValue()));
     }
 
     @Test
-    public void fluxIncoming() throws URISyntaxException, IOException, InterruptedException {
-        assertThat(getMetricValue(FLUX_INCOMING), is(notNullValue()));
+    public void fluxIncoming() {
+        await().until(() -> getMetricValue(FLUX_INCOMING), is(notNullValue()));
     }
 
     @Test
-    public void nafIncoming() throws URISyntaxException, IOException, InterruptedException {
-        assertThat(getMetricValue(NAF_INCOMING), is(notNullValue()));
+    public void nafIncoming() {
+        await().until(() -> getMetricValue(NAF_INCOMING), is(notNullValue()));
     }
 
     @Test
-    public void aisIncoming() throws URISyntaxException, IOException, InterruptedException {
-        try {
-            TimeUnit.MINUTES.sleep(2L);
-        } catch (InterruptedException e) {
-            System.out.println("Ais test waiting sleep was interrupted");
-        }
-        assertThat(getMetricValue(AIS_INCOMING), is(notNullValue()));
+    public void aisIncoming() {
+        await().until(() -> getMetricValue(AIS_INCOMING), is(notNullValue()));
     }
 
     @Test
-    public void restOutgoing() throws URISyntaxException, IOException, InterruptedException {
-        assertThat(getMetricValue(REST_OUTGOING), is(notNullValue()));
+    public void restOutgoing() {
+        await().until(() -> getMetricValue(REST_OUTGOING), is(notNullValue()));
     }
 
-    private String getMetricValue(String metricName) throws URISyntaxException, IOException, InterruptedException {
+    private String getMetricValue(String metricName) {
         Map<String, Map<String, String>> metrics = ClientBuilder.newClient()
                 .target("http://" + getHost() + ":29990/metrics")
                 .request(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Looks like the metric ais_incoming was not initialized on startup. To reduce the test time (i.e. not sleep for 2mins) the metric was moved in the AIS plugin to be available on startup instead.

Refs: FART-545