### PR TITLE
feat: changes to opendjk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <unionvms.wildfly.version>26.0.0.Final</unionvms.wildfly.version>
         <unionvms.project.unionvms.web.version>3.0.80</unionvms.project.unionvms.web.version>
         <unionvms.project.vms.web.version>1.2.0</unionvms.project.vms.web.version>
-        <unionvms.project.geoserver.version>2.25.3.1</unionvms.project.geoserver.version>
+        <unionvms.project.geoserver.version>2.25.3.2</unionvms.project.geoserver.version>
         <unionvms.project.user.module>2.2.6</unionvms.project.user.module>
         <unionvms.project.reporting.module>1.1.31</unionvms.project.reporting.module>
         <unionvms.project.movementrules.module>2.4.22</unionvms.project.movementrules.module>

--- a/wildfly-base/src/main/docker/Dockerfile
+++ b/wildfly-base/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.16.1_1_openj9-0.33.1-alpine-slim
+FROM adoptopenjdk/openjdk11:jdk-11.0.24_8-alpine-slim
 
 ARG WILDFLY_VERSION
 ENV JBOSS_HOME /opt/jboss/wildfly

--- a/wildfly-base/src/main/docker/standalone.conf
+++ b/wildfly-base/src/main/docker/standalone.conf
@@ -50,7 +50,7 @@ fi
 # Specify options to pass to the Java VM.
 #
 if [ "x$JAVA_OPTS" = "x" ]; then
-   JAVA_OPTS="-Xms1024m -Xmx4096m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Duser.timezone=UTC"
+   JAVA_OPTS="-Xms1024m -Xmx4096m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=1024m -Djava.net.preferIPv4Stack=true -Duser.timezone=UTC"
    JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true"
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"


### PR DESCRIPTION
dev, test, and prod is running on openjdk instead of openj9, tests should be run with the same distribution.

Includes the geoserver fix for org.reactivestreams.

Refs: KORT-1674